### PR TITLE
updated widgetsCard map in game component

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -18,7 +18,7 @@ const Game = () => {
       <div className="flex h-full w-3/4 flex-col gap-4">
         {widgetsCards.map((card, index) => (
           <WidgetsCard
-            key={index}
+            key={card.name}
             name={card.name}
             onRemove={removeWidgetCardByName}
           />


### PR DESCRIPTION
I'm not exactly sure what happens but you can see in the current build if you have 5 widgetCards and you got to delete Player 2 for example - sometimes it will delete Player 5 sometimes it will delete 4 & 5 but never delete P2 which is intended.

Changed the key to card.name and it worked.